### PR TITLE
supply air duct leakage fault model revised

### DIFF
--- a/lib/measures/SupplyAirDuctLeakages/measure.xml
+++ b/lib/measures/SupplyAirDuctLeakages/measure.xml
@@ -1,9 +1,10 @@
+<?xml version="1.0"?>
 <measure>
   <schema_version>3.0</schema_version>
   <name>supply_air_duct_leakages</name>
   <uid>8d568a70-080d-4f27-97f5-5210ff639652</uid>
-  <version_id>251fc058-8591-49d9-81e8-6079990a320e</version_id>
-  <version_modified>20200409T145325Z</version_modified>
+  <version_id>ac24cc14-1787-4eff-b635-4e19ff83e93f</version_id>
+  <version_modified>20210803T175126Z</version_modified>
   <xml_checksum>FAAEB4D1</xml_checksum>
   <class_name>SupplyAirDuctLeakages</class_name>
   <display_name>Supply Air Duct Leakages</display_name>
@@ -33,8 +34,8 @@
       <default_value>0.1</default_value>
     </argument>
   </arguments>
-  <outputs/>
-  <provenances/>
+  <outputs />
+  <provenances />
   <tags>
     <tag>HVAC.Ventilation</tag>
   </tags>
@@ -62,6 +63,12 @@
   </attributes>
   <files>
     <file>
+      <filename>README.md</filename>
+      <filetype>md</filetype>
+      <usage_type>readme</usage_type>
+      <checksum>14430263</checksum>
+    </file>
+    <file>
       <version>
         <software_program>OpenStudio</software_program>
         <identifier>1.5.0</identifier>
@@ -70,13 +77,7 @@
       <filename>measure.rb</filename>
       <filetype>rb</filetype>
       <usage_type>script</usage_type>
-      <checksum>2659C336</checksum>
-    </file>
-    <file>
-      <filename>README.md</filename>
-      <filetype>md</filetype>
-      <usage_type>readme</usage_type>
-      <checksum>14430263</checksum>
+      <checksum>2D5FB409</checksum>
     </file>
   </files>
 </measure>


### PR DESCRIPTION
**- Found:**
  - AirTerminal:SingleDuct:Uncontrolled object no longer available in EP v9.4
  - AirTerminal:SingleDuct:ConstantVolume:NoReheat included in LF59 model was not included in the measure

**- After modification:**
  - checked Constant Downstream Leakage Fraction in ZoneHVAC:AirDistributionUnit populated with fault intensity
  - annual simulation results difference between fault free and faulted (fault intensity 0.3) scenarios shown below
  
  
![image](https://user-images.githubusercontent.com/26775789/128071075-f0b5185a-7850-427d-8886-301b8ec0d4a4.png)

**- simulation results**
  - the way this fault mechanism works is basically pulling portion of air out right before it arrives to the space and putting that removed portion back before it gets back to the AHU
  - from AHU's perspective, you might retain favorable air condition from the return air, resulting in saved energy on cooling/heating coil in AHU
  - but it might cause thermal comfort issue
  - think the figure above is showing that result.
