### PR TITLE
duct fouling fault model revised

### DIFF
--- a/lib/measures/DuctFouling/measure.rb
+++ b/lib/measures/DuctFouling/measure.rb
@@ -108,7 +108,7 @@ class DuctFouling < OpenStudio::Ruleset::ModelUserScript
               delta_P = fan.pressureRise
               #delta_P = delta_P*(1+((1.-coeff[0])*flow_decrease_ratio*(flow_decrease_ratio-2)))
               delta_P = delta_P*(coeff[0]+(1-coeff[0])*(1-flow_decrease_ratio)*(1-flow_decrease_ratio))
-              max_flow = fan.getMaximumFlowRate
+              max_flow = fan.maximumFlowRate
               max_flow = max_flow.get
               max_flow = max_flow*(1.-flow_decrease_ratio)
               fan.setMaximumFlowRate(max_flow)
@@ -129,7 +129,7 @@ class DuctFouling < OpenStudio::Ruleset::ModelUserScript
               # change the maximum flow rate condition with the given fan curve
               # variables defined in a little bit different way to facilitate future modification
               old_delta_P = fan.pressureRise
-              old_max_flow = fan.getMaximumFlowRate
+              old_max_flow = fan.maximumFlowRate
 			  ###############################################
 			  old_min_v = fan.fanPowerMinimumAirFlowRate.get
               old_max_flow = old_max_flow.get.value
@@ -252,7 +252,7 @@ class DuctFouling < OpenStudio::Ruleset::ModelUserScript
               # variables defined in a little bit different way to facilitate future modification
               old_delta_P = fan.pressureRise
               delta_P = old_delta_P*(1+((1.-coeff[0])*flow_decrease_ratio*(flow_decrease_ratio-2)))
-              old_max_flow = fan.getMaximumFlowRate
+              old_max_flow = fan.maximumFlowRate
               old_max_flow = old_max_flow.get
               max_flow = old_max_flow*(1.-flow_decrease_ratio)
               fan.setMaximumFlowRate(max_flow)

--- a/lib/measures/DuctFouling/measure.xml
+++ b/lib/measures/DuctFouling/measure.xml
@@ -1,9 +1,10 @@
+<?xml version="1.0"?>
 <measure>
   <schema_version>3.0</schema_version>
   <name>duct_fouling</name>
   <uid>20a9d083-d915-4653-8893-d94a6dbc72d8</uid>
-  <version_id>b9b3a513-41a5-4786-905f-8782e01b5fc2</version_id>
-  <version_modified>20200409T145323Z</version_modified>
+  <version_id>e7b14b02-3e08-4f8c-b6b2-3e018210be14</version_id>
+  <version_modified>20210809T185624Z</version_modified>
   <xml_checksum>266557E5</xml_checksum>
   <class_name>DuctFouling</class_name>
   <display_name>Duct Fouling</display_name>
@@ -41,8 +42,8 @@
       <default_value>1.4048</default_value>
     </argument>
   </arguments>
-  <outputs/>
-  <provenances/>
+  <outputs />
+  <provenances />
   <tags>
     <tag>HVAC.Ventilation</tag>
   </tags>
@@ -76,6 +77,12 @@
       <checksum>BB22B43D</checksum>
     </file>
     <file>
+      <filename>README.md</filename>
+      <filetype>md</filetype>
+      <usage_type>readme</usage_type>
+      <checksum>25517DF7</checksum>
+    </file>
+    <file>
       <version>
         <software_program>OpenStudio</software_program>
         <identifier>1.5.0</identifier>
@@ -84,13 +91,7 @@
       <filename>measure.rb</filename>
       <filetype>rb</filetype>
       <usage_type>script</usage_type>
-      <checksum>58542651</checksum>
-    </file>
-    <file>
-      <filename>README.md</filename>
-      <filetype>md</filetype>
-      <usage_type>readme</usage_type>
-      <checksum>25517DF7</checksum>
+      <checksum>CFDE5EB6</checksum>
     </file>
   </files>
 </measure>


### PR DESCRIPTION
**Found:**
- getMaximumFlowRate method not working

**Testing for LF59:**
- using hard-sized LF59 model,
- replaced getMaximumFlowRate method to maximumFlowRate and it's working
- results (shown below) showed some difference in end use consumptions (not sure why faulted version is saving more energy tho)
![image](https://user-images.githubusercontent.com/26775789/128764642-0ccb3b03-4348-437c-b427-a4c1432c4617.png)

